### PR TITLE
Fix include path for clang to grab the proper intree path.

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -1,4 +1,4 @@
-AM_CXXFLAGS = `llvm-config --cxxflags` -Werror -Wall -std=c++11 -fno-strict-aliasing
+AM_CXXFLAGS = `llvm-config --cxxflags` -Werror -Wall -std=c++11 -fno-strict-aliasing -I`llvm-config --src-root`/tools/clang/include -I`llvm-config --obj-root`/tools/clang/include
 
 noinst_LTLIBRARIES = libsat.la
 lib_LTLIBRARIES    = liboptck.la liboptfe.la


### PR DESCRIPTION
I couldn't build on my machine because the clang includes were not found. This looks hackish but if you have the right llvm-config in the right place, it should work. (I override path prior to make)
