### PR TITLE
Describe how to build on Ubuntu, support clang-3.3

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -21,6 +21,20 @@ Then run in the LLVM build directory:
 This will install Clang and LLVM.  To use them, prepend their bin
 directory to PATH.
 
+Using distribution packages
+---------------------------
+STACK can be built against distribution-provided LLVM packages.
+On Ubuntu, install the needed packages:
+
+	$ apt-get install clang3.3 libclang-3.3-dev
+
+STACK uses llvm-config and opt, but Ubuntu only installs versioned
+versions of these commands. Add symlinks for them:
+
+	$ sudo ln -s /usr/bin/llvm-config-3.3 /usr/local/bin/llvm-config
+	$ sudo ln -s /usr/bin/opt-3.3 /usr/local/bin/opt
+
+After that, STACK can be built as described below.
 
 STACK
 -----

--- a/src/AntiFunctionPass.cc
+++ b/src/AntiFunctionPass.cc
@@ -1,6 +1,6 @@
 #include "AntiFunctionPass.h"
 #include <llvm/ADT/SCCIterator.h>
-#include <llvm/Analysis/CFG.h>
+#include <llvm/Transforms/Utils/BasicBlockUtils.h>
 #include <llvm/Analysis/Dominators.h>
 #include <llvm/Analysis/PostDominators.h>
 #include <llvm/IR/Instructions.h>


### PR DESCRIPTION
These patches describe how to build STACK on Ubuntu, and change one include-line so the code can be built using clang 3.3 (which probably means that it will fail to build on older versions of clang). 
