### PR TITLE
cc1: Fix execution with Python 3.

### DIFF
--- a/test/cc1
+++ b/test/cc1
@@ -52,7 +52,7 @@ def path_find(progname, dirs):
 	return progname
 
 def main():
-	llvmbindir = subprocess.check_output(['llvm-config', '--bindir']).strip()
+	llvmbindir = subprocess.check_output(['llvm-config', '--bindir'], universal_newlines=True).strip()
 	clangpath = path_find('clang', [llvmbindir, '/usr/bin', '/usr/local/bin'])
 	clang = clangpath + ' -no-integrated-as'
 	llvmcc = os.getenv('LLVMCC', clang).split(' ')


### PR DESCRIPTION
Python 3 causes subprocess.check_output to return a byte array, rather
than a string, leading to a confusing error message and failure to
produce any output at runtime.

Adding the universal_newlines=True forces the output to be a string
fixing this problem.
