### PR TITLE
Don't use xargs -I in poptck

### DIFF
--- a/src/poptck
+++ b/src/poptck
@@ -5,7 +5,7 @@ if [ "$1" = "-v" ]; then
   XARGSECHO=""
 else
   XARGSVERBOSE=""
-  XARGSECHO="echo Analyzing '{}' ;"
+  XARGSECHO="echo Analyzing \"\$0\" ;"
 fi
 
 DIR=$(dirname "${BASH_SOURCE[0]}")
@@ -13,9 +13,9 @@ NCPU=`${DIR}/ncpu`
 OUT='pstack.txt'
 TIMEOUT=5000
 TOTALSEC=1000
-find . -name '*.ll' -type f -print0 | xargs -0 -P ${NCPU} -I{} ${XARGSVERBOSE} bash -c "${XARGSECHO} ${DIR}/optck -smt-timeout=${TIMEOUT} -global-timeout-sec=${TOTALSEC} -enable-global-timeout '{}' > '{}.out'"
+find . -name '*.ll' -type f -print0 | xargs -0 -P ${NCPU} -n 1 ${XARGSVERBOSE} bash -c "${XARGSECHO} ${DIR}/optck -smt-timeout=${TIMEOUT} -global-timeout-sec=${TOTALSEC} -enable-global-timeout \"\$0\" > \"\$0.out\""
 rm -f ${OUT}
-find . -name '*.ll.out' -type f -print0 | xargs -0 -I{} bash -c "cat '{}' >> ${OUT}"
+find . -name '*.ll.out' -type f -print0 | xargs -0 -n 1 bash -c "cat \"\$0\" >> ${OUT}"
 
 NBUGS=`grep -c ^bug: ${OUT}`
 echo "Generated ${NBUGS} warnings, see ${OUT} for details."


### PR DESCRIPTION
Don't use xargs -I in poptck, on Darwin/Mac OS X this option will only expand argument strings up to a 255 byte limit
