### PR TITLE
Porting to the changes for latest LLVM 3.6

### DIFF
--- a/src/AntiAlgebra.cc
+++ b/src/AntiAlgebra.cc
@@ -12,7 +12,7 @@
 #include <llvm/Analysis/ScalarEvolutionExpressions.h>
 #include <llvm/IR/Constants.h>
 #include <llvm/IR/Instructions.h>
-#include <llvm/Support/InstIterator.h>
+#include <llvm/IR/InstIterator.h>
 #include <llvm/Target/TargetLibraryInfo.h>
 #include <llvm/Transforms/Utils/Local.h>
 #include <algorithm>

--- a/src/AntiDCE.cc
+++ b/src/AntiDCE.cc
@@ -5,12 +5,12 @@
 
 #define DEBUG_TYPE "anti-dce"
 #include "AntiFunctionPass.h"
-#include <llvm/Analysis/Dominators.h>
+#include <llvm/IR/Dominators.h>
 #include <llvm/Analysis/PostDominators.h>
 #include <llvm/IR/Constants.h>
 #include <llvm/IR/Function.h>
 #include <llvm/IR/Instructions.h>
-#include <llvm/Support/CFG.h>
+#include <llvm/IR/CFG.h>
 #include <llvm/Support/Debug.h>
 #include <llvm/Transforms/Utils/Local.h>
 
@@ -24,7 +24,7 @@ struct AntiDCE: AntiFunctionPass {
 
 	virtual void getAnalysisUsage(AnalysisUsage &AU) const {
 		AntiFunctionPass::getAnalysisUsage(AU);
-		AU.addPreserved<DominatorTree>();
+		AU.addPreserved<DominatorTreeWrapperPass>();
 		AU.addPreserved<PostDominatorTree>();
 	}
 

--- a/src/AntiFunctionPass.h
+++ b/src/AntiFunctionPass.h
@@ -6,7 +6,7 @@
 #include "ValueGen.h"
 #include <llvm/Pass.h>
 #include <llvm/ADT/SmallVector.h>
-#include <llvm/Analysis/Dominators.h>
+#include <llvm/IR/Dominators.h>
 #include <llvm/IR/DataLayout.h>
 
 #define BENCHMARK(e) if (BenchmarkFlag) { e; }
@@ -17,7 +17,7 @@ class SMTSolver;
 
 class AntiFunctionPass : public llvm::FunctionPass {
 protected:
-	llvm::DataLayout *DL;
+	const llvm::DataLayout *DL;
 	llvm::DominatorTree *DT;
 	llvm::SmallVector<PathGen::Edge, 32> Backedges;
 	Diagnostic Diag;

--- a/src/AntiSimplify.cc
+++ b/src/AntiSimplify.cc
@@ -6,7 +6,7 @@
 #include "AntiFunctionPass.h"
 #include <llvm/IR/Constants.h>
 #include <llvm/IR/Instructions.h>
-#include <llvm/Support/InstIterator.h>
+#include <llvm/IR/InstIterator.h>
 #include <llvm/Transforms/Utils/Local.h>
 
 using namespace llvm;

--- a/src/BugOn.cc
+++ b/src/BugOn.cc
@@ -4,8 +4,8 @@
 #include <llvm/Analysis/ValueTracking.h>
 #include <llvm/IR/Module.h>
 #include <llvm/Support/CommandLine.h>
-#include <llvm/Support/DebugLoc.h>
-#include <llvm/Support/InstIterator.h>
+#include <llvm/IR/DebugLoc.h>
+#include <llvm/IR/InstIterator.h>
 
 using namespace llvm;
 
@@ -73,7 +73,7 @@ bool BugOnPass::recursivelyClearDebugLoc(Value *V) {
 	return true;
 }
 
-Value *BugOnPass::getUnderlyingObject(Value *V, DataLayout *DL) {
+Value *BugOnPass::getUnderlyingObject(Value *V, const DataLayout *DL) {
 	return GetUnderlyingObject(V, DL, 1000);
 }
 

--- a/src/BugOn.h
+++ b/src/BugOn.h
@@ -44,12 +44,12 @@ struct BugOnPass : llvm::FunctionPass {
 	static bool clearDebugLoc(Value *);
 	static bool recursivelyClearDebugLoc(Value *);
 
-	static Value *getUnderlyingObject(Value *, DataLayout *);
+	static Value *getUnderlyingObject(Value *, const DataLayout *);
 	static Value *getAddressOperand(Value *, bool skipVolatile = false);
 	static Value *getNonvolatileAddressOperand(Value *V) {
 		return getAddressOperand(V, true);
 	}
-	static Value *getNonvolatileBaseAddress(Value *V, DataLayout *DL) {
+	static Value *getNonvolatileBaseAddress(Value *V, const DataLayout *DL) {
 		if (Value *P = getNonvolatileAddressOperand(V))
 			return getUnderlyingObject(P, DL);
 		return NULL;

--- a/src/BugOnAssert.cc
+++ b/src/BugOnAssert.cc
@@ -15,8 +15,8 @@
 #include <llvm/ADT/SmallPtrSet.h>
 #include <llvm/Analysis/ValueTracking.h>
 #include <llvm/IR/DataLayout.h>
-#include <llvm/Support/CFG.h>
-#include <llvm/Support/CallSite.h>
+#include <llvm/IR/CFG.h>
+#include <llvm/IR/CallSite.h>
 
 using namespace llvm;
 
@@ -34,7 +34,7 @@ struct BugOnAssert : BugOnPass {
 	virtual bool runOnInstruction(Instruction *) { return false; }
 
 private:
-	DataLayout *DL;
+	const DataLayout *DL;
 
 	bool simplify(Function &);
 	bool markInfiniteLoops(Function &);
@@ -50,7 +50,9 @@ private:
 bool BugOnAssert::runOnFunction(Function &F) {
 	IRBuilder<> TheBuilder(F.getContext());
 	Builder = &TheBuilder;
-	DL = getAnalysisIfAvailable<DataLayout>();
+  DataLayoutPass *DLP = getAnalysisIfAvailable<DataLayoutPass>();
+  if (DLP)
+    DL = &DLP->getDataLayout();
 	bool Changed = markInfiniteLoops(F);
 	for (Function::iterator i = F.begin(), e = F.end(); i != e; ) {
 		BasicBlock *BB = i++;

--- a/src/BugOnBounds.cc
+++ b/src/BugOnBounds.cc
@@ -13,13 +13,13 @@ struct BugOnBounds : BugOnPass {
 	static char ID;
 	BugOnBounds() : BugOnPass(ID) {
 		PassRegistry &Registry = *PassRegistry::getPassRegistry();
-		initializeDataLayoutPass(Registry);
+		initializeDataLayoutPassPass(Registry);
 		initializeTargetLibraryInfoPass(Registry);
 	}
 
 	virtual void getAnalysisUsage(AnalysisUsage &AU) const {
 		super::getAnalysisUsage(AU);
-		AU.addRequired<DataLayout>();
+		AU.addRequired<DataLayoutPass>();
 		AU.addRequired<TargetLibraryInfo>();
 	}
 
@@ -27,7 +27,7 @@ struct BugOnBounds : BugOnPass {
 	virtual bool runOnInstruction(Instruction *);
 
 private:
-	DataLayout *DL;
+	const DataLayout *DL;
 	TargetLibraryInfo *TLI;
 	ObjectSizeOffsetEvaluator *ObjSizeEval;
 };
@@ -35,7 +35,7 @@ private:
 } // anonymous namespace
 
 bool BugOnBounds::runOnFunction(llvm::Function &F) {
-	DL = &getAnalysis<DataLayout>();
+	DL = &getAnalysis<DataLayoutPass>().getDataLayout();
 	TLI = &getAnalysis<TargetLibraryInfo>();
 	ObjectSizeOffsetEvaluator TheObjSizeEval(DL, TLI, F.getContext());
 	ObjSizeEval = &TheObjSizeEval;

--- a/src/BugOnGep.cc
+++ b/src/BugOnGep.cc
@@ -18,7 +18,7 @@ struct BugOnGep : BugOnPass {
 
 	virtual void getAnalysisUsage(AnalysisUsage &AU) const {
 		super::getAnalysisUsage(AU);
-		AU.addRequired<DataLayout>();
+		AU.addRequired<DataLayoutPass>();
 		AU.addRequired<TargetLibraryInfo>();
 	}
 	virtual bool runOnFunction(Function &);
@@ -26,7 +26,7 @@ struct BugOnGep : BugOnPass {
 	virtual bool runOnInstruction(Instruction *);
 
 private:
-	DataLayout *DL;
+	const DataLayout *DL;
 	TargetLibraryInfo *TLI;
 
 	bool insertIndexOverflow(GEPOperator *GEP);
@@ -37,7 +37,7 @@ private:
 } // anonymous namespace
 
 bool BugOnGep::runOnFunction(Function &F) {
-	DL = &getAnalysis<DataLayout>();
+	DL = &getAnalysis<DataLayoutPass>().getDataLayout();
 	TLI = &getAnalysis<TargetLibraryInfo>();
 	return super::runOnFunction(F);
 }

--- a/src/BugOnLoop.cc
+++ b/src/BugOnLoop.cc
@@ -3,7 +3,7 @@
 
 #define DEBUG_TYPE "bugon-loop"
 #include "BugOn.h"
-#include <llvm/InstVisitor.h>
+#include <llvm/IR/InstVisitor.h>
 #include <llvm/Analysis/LoopInfo.h>
 #include <llvm/Analysis/ScalarEvolution.h>
 #include <llvm/Analysis/ScalarEvolutionExpander.h>

--- a/src/BugOnNull.cc
+++ b/src/BugOnNull.cc
@@ -12,26 +12,26 @@ struct BugOnNull : BugOnPass {
 	static char ID;
 	BugOnNull() : BugOnPass(ID) {
 		PassRegistry &Registry = *PassRegistry::getPassRegistry();
-		initializeDataLayoutPass(Registry);
+		initializeDataLayoutPassPass(Registry);
 	}
 
 	virtual void getAnalysisUsage(AnalysisUsage &AU) const {
 		super::getAnalysisUsage(AU);
-		AU.addRequired<DataLayout>();
+		AU.addRequired<DataLayoutPass>();
 	}
 
 	virtual bool runOnFunction(Function &);
 	virtual bool runOnInstruction(Instruction *);
 
 private:
-	DataLayout *DL;
+	const DataLayout *DL;
 	SmallPtrSet<Value *, 32> Visited;
 };
 
 } // anonymous namespace
 
 bool BugOnNull::runOnFunction(Function &F) {
-	DL = &getAnalysis<DataLayout>();
+	DL = &getAnalysis<DataLayoutPass>().getDataLayout();
 	return super::runOnFunction(F);
 }
 

--- a/src/BugOnUndef.cc
+++ b/src/BugOnUndef.cc
@@ -4,7 +4,7 @@
 #include "BugOn.h"
 #include <llvm/IR/Constants.h>
 #include <llvm/IR/Function.h>
-#include <llvm/Support/CallSite.h>
+#include <llvm/IR/CallSite.h>
 
 using namespace llvm;
 

--- a/src/Diagnostic.cc
+++ b/src/Diagnostic.cc
@@ -1,6 +1,6 @@
 #include "Diagnostic.h"
 #include "SMTSolver.h"
-#include <llvm/DebugInfo.h>
+#include <llvm/IR/DebugInfo.h>
 #include <llvm/ADT/SmallString.h>
 #include <llvm/IR/Instruction.h>
 #include <llvm/IR/Metadata.h>

--- a/src/ElimAssert.cc
+++ b/src/ElimAssert.cc
@@ -5,7 +5,7 @@
 #include <llvm/IR/BasicBlock.h>
 #include <llvm/IR/Function.h>
 #include <llvm/IR/Instructions.h>
-#include <llvm/Support/InstIterator.h>
+#include <llvm/IR/InstIterator.h>
 #include "Diagnostic.h"
 
 using namespace llvm;

--- a/src/LoadElim.cc
+++ b/src/LoadElim.cc
@@ -4,7 +4,7 @@
 #include <llvm/Analysis/MemoryDependenceAnalysis.h>
 #include <llvm/IR/Instructions.h>
 #include <llvm/Support/Debug.h>
-#include <llvm/Support/InstIterator.h>
+#include <llvm/IR/InstIterator.h>
 #include <llvm/Target/TargetLibraryInfo.h>
 #include <llvm/Transforms/Utils/Local.h>
 

--- a/src/LoopPrepare.cc
+++ b/src/LoopPrepare.cc
@@ -4,7 +4,7 @@
 #define DEBUG_TYPE "loop-prepare"
 #include <llvm/Pass.h>
 #include <llvm/IR/IRBuilder.h>
-#include <llvm/Support/InstIterator.h>
+#include <llvm/IR/InstIterator.h>
 
 using namespace llvm;
 

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -1,4 +1,4 @@
-AM_CXXFLAGS = `llvm-config --cxxflags` -Werror -Wall -std=c++11 -fno-strict-aliasing
+AM_CXXFLAGS = `llvm-config --cxxflags` -Werror -Wall -std=c++11 -fno-strict-aliasing -fno-rtti
 
 noinst_LTLIBRARIES = libsat.la
 lib_LTLIBRARIES    = liboptck.la liboptfe.la

--- a/src/PathGen.cc
+++ b/src/PathGen.cc
@@ -1,9 +1,9 @@
 #include "PathGen.h"
 #include "ValueGen.h"
-#include <llvm/Analysis/Dominators.h>
+#include <llvm/IR/Dominators.h>
 #include <llvm/IR/Constants.h>
 #include <llvm/IR/Instructions.h>
-#include <llvm/Support/CFG.h>
+#include <llvm/IR/CFG.h>
 
 using namespace llvm;
 

--- a/src/SimplifyDelete.cc
+++ b/src/SimplifyDelete.cc
@@ -4,7 +4,7 @@
 #define DEBUG_TYPE "simplify-delete"
 #include "BugOn.h"
 #include <llvm/Pass.h>
-#include <llvm/Analysis/Dominators.h>
+#include <llvm/IR/Dominators.h>
 #include <llvm/IR/BasicBlock.h>
 #include <llvm/IR/Function.h>
 #include <llvm/IR/Instructions.h>
@@ -19,11 +19,11 @@ struct SimplifyDelete : FunctionPass {
 	static char ID;
 	SimplifyDelete() : FunctionPass(ID) {
 		PassRegistry &Registry = *PassRegistry::getPassRegistry();
-		initializeDominatorTreePass(Registry);
+		initializeDominatorTreeWrapperPassPass(Registry);
 	}
 
 	void getAnalysisUsage(AnalysisUsage &AU) const {
-		AU.addRequired<DominatorTree>();
+		AU.addRequired<DominatorTreeWrapperPass>();
 	}
 
 	virtual bool runOnFunction(Function &);
@@ -50,7 +50,7 @@ bool SimplifyDelete::runOnFunction(Function &F) {
 }
 
 bool SimplifyDelete::removeUnreachable(Function &F) {
-	DominatorTree &DT = getAnalysis<DominatorTree>();
+	DominatorTree &DT = getAnalysis<DominatorTreeWrapperPass>().getDomTree();
 	SmallVector<BasicBlock *, 4> UnreachableBB;
 	for (BasicBlock &BB : F) {
 		if (DT.isReachableFromEntry(&BB))

--- a/src/ValueGen.cc
+++ b/src/ValueGen.cc
@@ -1,10 +1,10 @@
 #include "ValueGen.h"
-#include <llvm/InstVisitor.h>
+#include <llvm/IR/InstVisitor.h>
 #include <llvm/ADT/APInt.h>
 #include <llvm/IR/Constants.h>
 #include <llvm/IR/IntrinsicInst.h>
 #include <llvm/IR/Operator.h>
-#include <llvm/Support/GetElementPtrTypeIterator.h>
+#include <llvm/IR/GetElementPtrTypeIterator.h>
 #include <llvm/Support/raw_ostream.h>
 #include <assert.h>
 
@@ -283,7 +283,7 @@ private:
 
 } // anonymous namespace
 
-ValueGen::ValueGen(DataLayout &TD, SMTSolver &SMT)
+ValueGen::ValueGen(const DataLayout &TD, SMTSolver &SMT)
 	: TD(TD), SMT(SMT) {}
 
 ValueGen::~ValueGen() {

--- a/src/ValueGen.h
+++ b/src/ValueGen.h
@@ -6,14 +6,14 @@
 
 class ValueGen {
 public:
-	llvm::DataLayout &TD;
+	const llvm::DataLayout &TD;
 	SMTSolver &SMT;
 
 	typedef llvm::DenseMap<llvm::Value *, SMTExpr> ValueExprMap;
 	typedef ValueExprMap::iterator iterator;
 	ValueExprMap Cache;
 
-	ValueGen(llvm::DataLayout &, SMTSolver &);
+	ValueGen(const llvm::DataLayout &, SMTSolver &);
 	~ValueGen();
 
 	static bool isAnalyzable(llvm::Value *);


### PR DESCRIPTION
Hi Xi Wang,
I like your project very much and I think this is very useful for analyzing unsafe compiler optimizations. I'm submitting this patch which ports the sources to compile with latest llvm 3.6.
Please review the patch and submit if you like it. Also, I have a request, can you rewrite the 'diagdiff' script to python/perl? I'm not at all familiar with ruby and I'm having hard time running that script because my system has a different version of YAML libraries for ruby.

hth,
-Aditya
